### PR TITLE
Fix bug with code coverage being zero percent when running all tests together

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,7 +35,7 @@ android {
     }
     testOptions {
         unitTests.all {
-
+            jvmArgs '-noverify'
             jacoco {
                 includeNoLocationClasses = true
             }


### PR DESCRIPTION
Before this change unit tests would run successfully, but the code coverage would be zero percent for some classes that had tests including `OverallStatisticsCalculator`